### PR TITLE
TWEAK: Add way to specify a pattern for a field, eg regex for a string input

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -75,6 +75,7 @@ type DecoderField struct {
 	needsAllocation bool // true if we need to reflect.New
 	Default         string
 	Doc             string
+	Pattern         string
 
 	*SliceOptions
 
@@ -181,6 +182,7 @@ func NewDecoder(destStruct interface{}) *Decoder {
 			}
 
 			dfield.Doc = fieldStruct.Tag.Get("doc")
+			dfield.Pattern = fieldStruct.Tag.Get("pattern")
 
 			// Determine what kind of field it is.
 			if metaName == "*" && indirectedKind == reflect.Map {

--- a/meta.go
+++ b/meta.go
@@ -75,7 +75,7 @@ type DecoderField struct {
 	needsAllocation bool // true if we need to reflect.New
 	Default         string
 	Doc             string
-	Pattern         string
+	DocPattern      string
 
 	*SliceOptions
 
@@ -182,7 +182,7 @@ func NewDecoder(destStruct interface{}) *Decoder {
 			}
 
 			dfield.Doc = fieldStruct.Tag.Get("doc")
-			dfield.Pattern = fieldStruct.Tag.Get("pattern")
+			dfield.DocPattern = fieldStruct.Tag.Get("doc_pattern")
 
 			// Determine what kind of field it is.
 			if metaName == "*" && indirectedKind == reflect.Map {


### PR DESCRIPTION
In addition to `Doc`, a field for descriptions of a meta field, adding a `DocPattern` to specify any input regex for a meta field.