### PR TITLE
TWEAK: Handle self-referencing param structs

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -230,7 +230,11 @@ func NewDecoderWithOptions(destStruct interface{}, options DecoderOptions) *Deco
 					dfield.Options = getParsedOptions(valuer, fieldStruct, options)
 				} else if elemIndirectedKind == reflect.Struct {
 					dfield.fieldCategory = categorySliceOfStructs
-					dfield.StructDecoder = NewDecoderWithOptions(reflect.New(elemIndirectedType).Interface(), options)
+					if elemIndirectedType == destType {
+						dfield.StructDecoder = decoder
+					} else {
+						dfield.StructDecoder = NewDecoderWithOptions(reflect.New(elemIndirectedType).Interface(), options)
+					}
 				} else {
 					panic("unknown type of slice")
 				}

--- a/meta_test.go
+++ b/meta_test.go
@@ -154,4 +154,25 @@ func TestNestedMetaStar(t *testing.T) {
 	assertEqual(t, inputs.Nested.AllFields["a_field"], "A field")
 }
 
+type WithSelfReference struct {
+	Name     String
+	Children []*WithSelfReference
+}
+
+var withSelfReferenceDecoder = NewDecoder(WithSelfReference{})
+
+func TestWithSelfReference(t *testing.T) {
+	var inputs WithSelfReference
+	e := withSelfReferenceDecoder.Decode(&inputs, nil, []byte(`{"name": "parent", "children": [{"name": "child 1"}, {"name": "child 2", "children": [{"name": "grandchild"}]}]}`))
+	assertEqual(t, e, ErrorHash(nil))
+	assertEqual(t, inputs.Name.Val, "parent")
+	assertEqual(t, len(inputs.Children), 2)
+	assertEqual(t, inputs.Children[0].Name.Val, "child 1")
+	assertEqual(t, len(inputs.Children[0].Children), 0)
+	assertEqual(t, inputs.Children[1].Name.Val, "child 2")
+	assertEqual(t, len(inputs.Children[1].Children), 1)
+	assertEqual(t, inputs.Children[1].Children[0].Name.Val, "grandchild")
+	assertEqual(t, len(inputs.Children[1].Children[0].Children), 0)
+}
+
 // TODO: test default values


### PR DESCRIPTION
If you need to handle JSON params that form a tree structure of arbitrary depth, meta will produce a `goroutine stack exceeds 1000000000-byte limit` error. This PR fixes this by detecting self-references in a struct type and reusing the same decoder for them. (This PR does not handle the issue of cycles among multiple types, as it would add more complexity and I don't have a use-case for it.)