### PR TITLE
FEATURE: expose JsonLoader interface for customizations

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -115,7 +115,7 @@ func (b Bool) Value() (driver.Value, error) {
 
 func (b Bool) MarshalJSON() ([]byte, error) {
 	if b.Present && !b.Null {
-		return json.Marshal(b.Val)
+		return MetaJson.Marshal(b.Val)
 	}
 	return nullString, nil
 }

--- a/errors.go
+++ b/errors.go
@@ -1,9 +1,5 @@
 package meta
 
-import (
-	"encoding/json"
-)
-
 type Errorable interface {
 	// Errorable should be a go error
 	error
@@ -39,7 +35,7 @@ func (e ErrorAtom) Error() string {
 }
 
 func (eh ErrorHash) Error() string {
-	j, _ := json.Marshal(eh)
+	j, _ := MetaJson.Marshal(eh)
 	return string(j)
 }
 

--- a/float.go
+++ b/float.go
@@ -158,7 +158,7 @@ func (i Float64) Value() (driver.Value, error) {
 
 func (i Float64) MarshalJSON() ([]byte, error) {
 	if i.Present && !i.Null {
-		return json.Marshal(i.Val)
+		return MetaJson.Marshal(i.Val)
 	}
 	return nullString, nil
 }

--- a/int.go
+++ b/int.go
@@ -305,14 +305,14 @@ func (i Uint64) Value() (driver.Value, error) {
 
 func (i Int64) MarshalJSON() ([]byte, error) {
 	if i.Present && !i.Null {
-		return json.Marshal(i.Val)
+		return MetaJson.Marshal(i.Val)
 	}
 	return nullString, nil
 }
 
 func (i Uint64) MarshalJSON() ([]byte, error) {
 	if i.Present && !i.Null {
-		return json.Marshal(i.Val)
+		return MetaJson.Marshal(i.Val)
 	}
 	return nullString, nil
 }

--- a/json.go
+++ b/json.go
@@ -1,0 +1,36 @@
+package meta
+
+import (
+	"encoding/json"
+	"bytes"
+)
+
+var MetaJson JsonLoader
+
+func init() {
+	MetaJson = &defaultJsonLoader{}
+}
+
+// Expose json loader interface that can be implemneted in client code for customization
+type JsonLoader interface {
+	Marshal(v interface{}) ([]byte, error)
+	Unmarshal(data []byte, v interface{}) error
+	UnmarshalUsingNumber(data []byte, v interface{}) error
+}
+
+// Default implementation of Json loader just uses Go's standard json lib
+type defaultJsonLoader struct {}
+
+func (j *defaultJsonLoader) Marshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func (j *defaultJsonLoader) Unmarshal(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
+}
+
+func (j *defaultJsonLoader) UnmarshalUsingNumber(data []byte, v interface{}) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	return dec.Decode(v)
+}

--- a/source.go
+++ b/source.go
@@ -1,7 +1,6 @@
 package meta
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/url"
 	"strconv"
@@ -111,7 +110,7 @@ func (jv *jsonSource) Get(key string) source {
 	i, err := strconv.Atoi(key)
 	if err == nil {
 		var slice []json.RawMessage
-		err = json.Unmarshal(jv.RawMessage, &slice)
+		err = MetaJson.Unmarshal(jv.RawMessage, &slice)
 		if err != nil {
 			s.malformed = true
 			return s
@@ -123,7 +122,7 @@ func (jv *jsonSource) Get(key string) source {
 		return s
 	}
 	var m map[string]json.RawMessage
-	err = json.Unmarshal(jv.RawMessage, &m)
+	err = MetaJson.Unmarshal(jv.RawMessage, &m)
 	if err != nil {
 		s.malformed = true
 		return s
@@ -141,9 +140,7 @@ func (jv *jsonSource) Value(i interface{}) Errorable {
 		return ErrBlank
 	}
 
-	dec := json.NewDecoder(bytes.NewReader(jv.RawMessage))
-	dec.UseNumber()
-	err := dec.Decode(i)
+	err := MetaJson.UnmarshalUsingNumber(jv.RawMessage, i)
 	if err != nil {
 		return ErrMalformed
 	}
@@ -152,9 +149,9 @@ func (jv *jsonSource) Value(i interface{}) Errorable {
 
 func (jv *jsonSource) ValueMap() map[string]interface{} {
 	var out map[string]interface{}
-	dec := json.NewDecoder(bytes.NewReader(jv.RawMessage))
-	dec.UseNumber()
-	if err := dec.Decode(&out); err != nil {
+
+	err := MetaJson.UnmarshalUsingNumber(jv.RawMessage, &out)
+	if err != nil {
 		return nil
 	}
 	return out

--- a/string.go
+++ b/string.go
@@ -219,7 +219,7 @@ func (s String) Value() (driver.Value, error) {
 
 func (s String) MarshalJSON() ([]byte, error) {
 	if s.Present && !s.Null {
-		return json.Marshal(s.Val)
+		return MetaJson.Marshal(s.Val)
 	}
 	return nullString, nil
 }

--- a/time.go
+++ b/time.go
@@ -2,7 +2,6 @@ package meta
 
 import (
 	"database/sql/driver"
-	"encoding/json"
 	"reflect"
 	"time"
 )
@@ -107,7 +106,7 @@ func (t Time) Value() (driver.Value, error) {
 
 func (t Time) MarshalJSON() ([]byte, error) {
 	if t.Present && !t.Null {
-		return json.Marshal(t.Val)
+		return MetaJson.Marshal(t.Val)
 	}
 	return nullString, nil
 }


### PR DESCRIPTION
Adding the `JsonLoader` interface allows client code to experiment with using alternatives to the standard `encoding/json` libraries for performance gains in meta. 