### PR TITLE
FEATURE: Meta types keep track of their path

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -15,6 +15,7 @@ type Bool struct {
 	Val bool
 	Nullity
 	Presence
+	Path string
 }
 
 type BoolOptions struct {
@@ -24,7 +25,7 @@ type BoolOptions struct {
 }
 
 func NewBool(b bool) Bool {
-	return Bool{b, Nullity{false}, Presence{true}}
+	return Bool{b, Nullity{false}, Presence{true}, ""}
 }
 
 func (b *Bool) ParseOptions(tag reflect.StructTag) interface{} {
@@ -77,8 +78,9 @@ func (b *Bool) FormValue(value string, options interface{}) Errorable {
 	return ErrBool
 }
 
-func (b *Bool) JSONValue(i interface{}, options interface{}) Errorable {
+func (b *Bool) JSONValue(path string, i interface{}, options interface{}) Errorable {
 	opts := options.(*BoolOptions)
+	b.Path = path
 
 	if i == nil {
 		if opts.Null {

--- a/float.go
+++ b/float.go
@@ -16,6 +16,7 @@ type Float64 struct {
 	Val float64
 	Nullity
 	Presence
+	Path string
 }
 
 type FloatOptions struct {
@@ -30,7 +31,7 @@ type FloatOptions struct {
 }
 
 func NewFloat64(f float64) Float64 {
-	return Float64{f, Nullity{false}, Presence{true}}
+	return Float64{f, Nullity{false}, Presence{true}, ""}
 }
 
 func (i *Float64) ParseOptions(tag reflect.StructTag) interface{} {
@@ -84,7 +85,8 @@ func (i *Float64) ParseOptions(tag reflect.StructTag) interface{} {
 	return opts
 }
 
-func (f *Float64) JSONValue(i interface{}, options interface{}) Errorable {
+func (f *Float64) JSONValue(path string, i interface{}, options interface{}) Errorable {
+	f.Path = path
 	if i == nil {
 		return f.FormValue("", options)
 	}

--- a/int.go
+++ b/int.go
@@ -16,12 +16,14 @@ type Int64 struct {
 	Val int64
 	Nullity
 	Presence
+	Path string
 }
 
 type Uint64 struct {
 	Val uint64
 	Nullity
 	Presence
+	Path string
 }
 
 type IntOptions struct {
@@ -47,11 +49,11 @@ type UintOptions struct {
 }
 
 func NewInt64(val int64) Int64 {
-	return Int64{val, Nullity{false}, Presence{true}}
+	return Int64{val, Nullity{false}, Presence{true}, ""}
 }
 
 func NewUint64(val uint64) Uint64 {
-	return Uint64{val, Nullity{false}, Presence{true}}
+	return Uint64{val, Nullity{false}, Presence{true}, ""}
 }
 
 func (i *Int64) ParseOptions(tag reflect.StructTag) interface{} {
@@ -156,7 +158,8 @@ func (i *Uint64) ParseOptions(tag reflect.StructTag) interface{} {
 	return opts
 }
 
-func (n *Int64) JSONValue(i interface{}, options interface{}) Errorable {
+func (n *Int64) JSONValue(path string, i interface{}, options interface{}) Errorable {
+	n.Path = path
 	if i == nil {
 		return n.FormValue("", options)
 	}
@@ -222,7 +225,8 @@ func (i *Int64) FormValue(value string, options interface{}) Errorable {
 	return nil
 }
 
-func (n *Uint64) JSONValue(i interface{}, options interface{}) Errorable {
+func (n *Uint64) JSONValue(path string, i interface{}, options interface{}) Errorable {
+	n.Path = path
 	if i == nil {
 		return n.FormValue("", options)
 	}

--- a/int_slice.go
+++ b/int_slice.go
@@ -10,7 +10,8 @@ import (
 //
 
 type Int64Slice struct {
-	Val []int64
+	Val  []int64
+	Path string
 }
 
 type IntSliceOptions struct {
@@ -27,7 +28,8 @@ func (i *Int64Slice) ParseOptions(tag reflect.StructTag) interface{} {
 	}
 }
 
-func (n *Int64Slice) JSONValue(i interface{}, options interface{}) Errorable {
+func (n *Int64Slice) JSONValue(path string, i interface{}, options interface{}) Errorable {
+	n.Path = path
 	n.Val = nil
 	if i == nil {
 		return ErrBlank
@@ -55,7 +57,7 @@ func (n *Int64Slice) JSONValue(i interface{}, options interface{}) Errorable {
 
 		for _, v := range value {
 			var num Int64
-			if err := num.JSONValue(v, intOpts); err != nil {
+			if err := num.JSONValue("", v, intOpts); err != nil {
 				errorsInSlice = append(errorsInSlice, err)
 			} else {
 				errorsInSlice = append(errorsInSlice, nil)

--- a/meta.go
+++ b/meta.go
@@ -11,7 +11,7 @@ import (
 
 type Valuer interface {
 	ParseOptions(tag reflect.StructTag) interface{}
-	JSONValue(value interface{}, options interface{}) Errorable
+	JSONValue(path string, value interface{}, options interface{}) Errorable
 }
 
 var (
@@ -315,7 +315,7 @@ func (d *Decoder) decode(destValue reflect.Value, src source) ErrorHash {
 					fieldValue.Set(reflect.New(dfield.indirectedType))
 					valuerValue = fieldValue
 				}
-				err = valuerValue.Interface().(Valuer).JSONValue(val, dfield.Options)
+				err = valuerValue.Interface().(Valuer).JSONValue(nestedValues.Path(), val, dfield.Options)
 				if err != nil && !dfield.DiscardInvalid {
 					errs = addError(errs, metaName, err)
 				}
@@ -365,7 +365,7 @@ func (d *Decoder) decode(destValue reflect.Value, src source) ErrorHash {
 				var val interface{}
 				nestedValues.Value(&val)
 				elPtrValue := reflect.New(dfield.elemIndirectedType)
-				err := elPtrValue.Interface().(Valuer).JSONValue(val, dfield.Options)
+				err := elPtrValue.Interface().(Valuer).JSONValue(nestedValues.Path(), val, dfield.Options)
 				if err != nil {
 					errorsInSlice = append(errorsInSlice, err)
 				} else {

--- a/meta_test.go
+++ b/meta_test.go
@@ -46,6 +46,7 @@ func TestNewDecoder(t *testing.T) {
 	e = withMetaNameDecoder.DecodeJSON(&inputs, []byte(`{"with_camel_case":1,"poopin":2,"ignored":3}`))
 	assertEqual(t, e, ErrorHash(nil))
 	assertEqual(t, inputs.WithCamelCase.Val, "1")
+	assertEqual(t, inputs.WithCamelCase.Path, "with_camel_case")
 	assertEqual(t, inputs.OtherField.Val, "2")
 	assertEqual(t, inputs.Ignored.Val, "")
 }
@@ -107,13 +108,13 @@ func TestValuers(t *testing.T) {
 	assertEqual(t, "", v)
 
 	// Int
-	i64 := Int64{1, Nullity{false}, Presence{true}}
+	i64 := Int64{1, Nullity{false}, Presence{true}, ""}
 	valuer = i64
 	v, err = valuer.Value()
 	assert(t, err == nil)
 	assertEqual(t, int64(1), v)
 
-	ui64 := Uint64{1, Nullity{false}, Presence{true}}
+	ui64 := Uint64{1, Nullity{false}, Presence{true}, ""}
 	valuer = ui64
 	v, err = valuer.Value()
 	assert(t, err == nil)
@@ -173,6 +174,7 @@ func TestWithSelfReference(t *testing.T) {
 	assertEqual(t, len(inputs.Children[1].Children), 1)
 	assertEqual(t, inputs.Children[1].Children[0].Name.Val, "grandchild")
 	assertEqual(t, len(inputs.Children[1].Children[0].Children), 0)
+	assertEqual(t, inputs.Children[1].Children[0].Name.Path, "children.1.children.0.name")
 }
 
 // TODO: test default values

--- a/string.go
+++ b/string.go
@@ -18,6 +18,7 @@ type String struct {
 	Val string
 	Nullity
 	Presence
+	Path string
 }
 
 type StringOptions struct {
@@ -36,7 +37,7 @@ type StringOptions struct {
 }
 
 func NewString(s string) String {
-	return String{s, Nullity{false}, Presence{true}}
+	return String{s, Nullity{false}, Presence{true}, ""}
 }
 
 func (s *String) ParseOptions(tag reflect.StructTag) interface{} {
@@ -114,7 +115,8 @@ func (s *String) ParseOptions(tag reflect.StructTag) interface{} {
 	return opts
 }
 
-func (s *String) JSONValue(i interface{}, options interface{}) Errorable {
+func (s *String) JSONValue(path string, i interface{}, options interface{}) Errorable {
+	s.Path = path
 	if i == nil {
 		opts := options.(*StringOptions)
 		if opts.Null {

--- a/string_slice.go
+++ b/string_slice.go
@@ -7,7 +7,8 @@ import (
 )
 
 type StringSlice struct {
-	Val []string
+	Val  []string
+	Path string
 }
 
 type StringSliceOptions struct {
@@ -32,7 +33,8 @@ func (i *StringSlice) ParseOptions(tag reflect.StructTag) interface{} {
 	}
 }
 
-func (n *StringSlice) JSONValue(i interface{}, options interface{}) Errorable {
+func (n *StringSlice) JSONValue(path string, i interface{}, options interface{}) Errorable {
+	n.Path = path
 	n.Val = nil
 	if i == nil {
 		return ErrBlank
@@ -60,7 +62,7 @@ func (n *StringSlice) JSONValue(i interface{}, options interface{}) Errorable {
 
 		for _, v := range value {
 			var s String
-			if err := s.JSONValue(v, stringOpts); err != nil {
+			if err := s.JSONValue("", v, stringOpts); err != nil {
 				errorsInSlice = append(errorsInSlice, err)
 				if err == ErrBlank && !opts.DiscardBlank {
 					n.Val = append(n.Val, s.Val)

--- a/time.go
+++ b/time.go
@@ -14,6 +14,7 @@ type Time struct {
 	Val time.Time
 	Nullity
 	Presence
+	Path string
 }
 
 type TimeOptions struct {
@@ -24,7 +25,7 @@ type TimeOptions struct {
 }
 
 func NewTime(t time.Time) Time {
-	return Time{t, Nullity{false}, Presence{true}}
+	return Time{t, Nullity{false}, Presence{true}, ""}
 }
 
 func (t *Time) ParseOptions(tag reflect.StructTag) interface{} {
@@ -54,7 +55,8 @@ func (t *Time) ParseOptions(tag reflect.StructTag) interface{} {
 	return opts
 }
 
-func (t *Time) JSONValue(i interface{}, options interface{}) Errorable {
+func (t *Time) JSONValue(path string, i interface{}, options interface{}) Errorable {
+	t.Path = path
 	if i == nil {
 		return t.FormValue("", options)
 	}


### PR DESCRIPTION
This PR adds a `Path` member to each meta struct which will be populated with the key path that was used to set the value of that struct. This is useful for constructing accurate error messages when applying custom validation rules.