### PR TITLE
TWEAK: Handle native types in Valuers for the sake of DecodeMap

### DIFF
--- a/bool_test.go
+++ b/bool_test.go
@@ -54,6 +54,12 @@ func TestBoolSuccess(t *testing.T) {
 		assertEqual(t, inputs.A.Val, false)
 		assertEqual(t, inputs.A.Present, true)
 	}
+
+	var inputs withBool
+	e := withBoolDecoder.DecodeMap(&inputs, map[string]interface{}{"a": true})
+	assertEqual(t, e, ErrorHash(nil))
+	assertEqual(t, inputs.A.Val, true)
+	assertEqual(t, inputs.A.Present, true)
 }
 
 func TestBoolBlank(t *testing.T) {

--- a/float.go
+++ b/float.go
@@ -92,6 +92,10 @@ func (f *Float64) JSONValue(path string, i interface{}, options interface{}) Err
 	}
 
 	switch value := i.(type) {
+	case float64:
+		f.Val = value
+		f.Present = true
+		return nil
 	case json.Number:
 		return f.FormValue(string(value), options)
 	case string:

--- a/float_test.go
+++ b/float_test.go
@@ -46,6 +46,16 @@ func TestFloatSuccess(t *testing.T) {
 	assertEqual(t, inputs.B.Val, float64(2))
 	assertEqual(t, inputs.B.Present, true)
 	assertEqual(t, inputs.B.Null, false)
+
+	inputs = withFloat{}
+	e = withFloatDecoder.DecodeMap(&inputs, map[string]interface{}{"a": -1.1, "b": 2.2})
+	assertEqual(t, e, ErrorHash(nil))
+	assertEqual(t, inputs.A.Val, -1.1)
+	assertEqual(t, inputs.A.Present, true)
+	assertEqual(t, inputs.A.Null, false)
+	assertEqual(t, inputs.B.Val, 2.2)
+	assertEqual(t, inputs.B.Present, true)
+	assertEqual(t, inputs.B.Null, false)
 }
 
 func TestFloatBlank(t *testing.T) {

--- a/int.go
+++ b/int.go
@@ -165,6 +165,14 @@ func (n *Int64) JSONValue(path string, i interface{}, options interface{}) Error
 	}
 
 	switch value := i.(type) {
+	case int:
+		n.Val = int64(value)
+		n.Present = true
+		return nil
+	case int64:
+		n.Val = value
+		n.Present = true
+		return nil
 	case json.Number:
 		return n.FormValue(string(value), options)
 	case string:

--- a/int_slice_test.go
+++ b/int_slice_test.go
@@ -37,6 +37,10 @@ func TestIntSliceSuccess(t *testing.T) {
 	e = withIntSliceDecoder.DecodeJSON(&inputs, []byte(`{"a":[-2,9,"30"]}`))
 	assertEqual(t, e, ErrorHash(nil))
 	assertEqual(t, inputs.A.Val, []int64{-2, 9, 30})
+
+	e = withIntSliceDecoder.DecodeMap(&inputs, map[string]interface{}{"a": []interface{}{-2, 9}})
+	assertEqual(t, e, ErrorHash(nil))
+	assertEqual(t, inputs.A.Val, []int64{-2, 9})
 }
 
 func TestIntSliceBlank(t *testing.T) {

--- a/int_test.go
+++ b/int_test.go
@@ -30,6 +30,12 @@ func TestIntSuccess(t *testing.T) {
 	assertEqual(t, e, ErrorHash(nil))
 	assertEqual(t, inputs.A.Val, int64(-1))
 	assertEqual(t, inputs.B.Val, int64(2))
+
+	inputs = withInt{}
+	e = withIntDecoder.DecodeMap(&inputs, map[string]interface{}{"a": -1, "b": 2})
+	assertEqual(t, e, ErrorHash(nil))
+	assertEqual(t, inputs.A.Val, int64(-1))
+	assertEqual(t, inputs.B.Val, int64(2))
 }
 
 func TestIntBlank(t *testing.T) {

--- a/string_slice_test.go
+++ b/string_slice_test.go
@@ -44,6 +44,11 @@ func TestStringSliceSuccess(t *testing.T) {
 	e = withStringSliceDecoder.DecodeJSON(&inputs, []byte(`{"a":["rrr", true, false, 1]}`))
 	assertEqual(t, e, ErrorHash(nil))
 	assertEqual(t, inputs.A.Val, []string{"rrr", "true", "false", "1"})
+
+	// decode map
+	e = withStringSliceDecoder.DecodeMap(&inputs, map[string]interface{}{"a": []interface{}{"aaa", "bbb"}})
+	assertEqual(t, e, ErrorHash(nil))
+	assertEqual(t, inputs.A.Val, []string{"aaa", "bbb"})
 }
 
 func TestStringSliceBlank(t *testing.T) {

--- a/string_test.go
+++ b/string_test.go
@@ -24,6 +24,11 @@ func TestStringSuccess(t *testing.T) {
 	assertEqual(t, e, ErrorHash(nil))
 	assertEqual(t, inputs.A.Val, "Okay")
 	assertEqual(t, inputs.A.Present, true)
+
+	e = withStringDecoder.DecodeMap(&inputs, map[string]interface{}{"a": "Okay"})
+	assertEqual(t, e, ErrorHash(nil))
+	assertEqual(t, inputs.A.Val, "Okay")
+	assertEqual(t, inputs.A.Present, true)
 }
 
 func TestStringRequired(t *testing.T) { // Missing -> required

--- a/time.go
+++ b/time.go
@@ -62,6 +62,26 @@ func (t *Time) JSONValue(path string, i interface{}, options interface{}) Errora
 	}
 
 	switch value := i.(type) {
+	case time.Time:
+		if value.IsZero() {
+			opts := options.(*TimeOptions)
+			if opts.Null {
+				t.Present = true
+				t.Null = true
+				return nil
+			}
+			if opts.Required {
+				return ErrBlank
+			}
+			if !opts.DiscardBlank {
+				t.Present = true
+				return ErrBlank
+			}
+			return nil
+		}
+		t.Present = true
+		t.Val = value
+		return nil
 	case string:
 		return t.FormValue(value, options)
 	}

--- a/time_test.go
+++ b/time_test.go
@@ -24,6 +24,11 @@ func TestTimeSuccess(t *testing.T) {
 	assertEqual(t, e, ErrorHash(nil))
 	assert(t, inputs.A.Val.Equal(time.Date(2016, 6, 2, 16, 33, 22, 0, time.UTC)))
 	assertEqual(t, inputs.A.Present, true)
+
+	e = withTimeDecoder.DecodeMap(&inputs, map[string]interface{}{"a": time.Date(2016, 6, 2, 16, 33, 22, 0, time.UTC)})
+	assertEqual(t, e, ErrorHash(nil))
+	assert(t, inputs.A.Val.Equal(time.Date(2016, 6, 2, 16, 33, 22, 0, time.UTC)))
+	assertEqual(t, inputs.A.Present, true)
 }
 
 func TestTimeBlank(t *testing.T) {
@@ -34,6 +39,10 @@ func TestTimeBlank(t *testing.T) {
 	assertEqual(t, inputs.A.Present, false)
 
 	e = withTimeDecoder.DecodeJSON(&inputs, []byte(`{"a":""}`))
+	assertEqual(t, e, ErrorHash{"a": ErrBlank})
+	assertEqual(t, inputs.A.Present, false)
+
+	e = withTimeDecoder.DecodeMap(&inputs, map[string]interface{}{"a": time.Time{}})
 	assertEqual(t, e, ErrorHash{"a": ErrBlank})
 	assertEqual(t, inputs.A.Present, false)
 }
@@ -137,6 +146,11 @@ func TestOptionalTimeBlank(t *testing.T) {
 	assertEqual(t, e, ErrorHash(nil))
 	assertEqual(t, inputs.A.Present, false)
 	assert(t, inputs.A.Val.IsZero())
+
+	e = withOptionalTimeDecoder.DecodeMap(&inputs, map[string]interface{}{"a": time.Time{}})
+	assertEqual(t, e, ErrorHash(nil))
+	assertEqual(t, inputs.A.Present, false)
+	assert(t, inputs.A.Val.IsZero())
 }
 
 func TestOptionalTimeBlankFailure(t *testing.T) {
@@ -151,6 +165,9 @@ func TestOptionalTimeBlankFailure(t *testing.T) {
 	assertEqual(t, e, ErrorHash{"a": ErrBlank})
 
 	e = NewDecoder(&inputs).DecodeJSON(&inputs, []byte(`{"a":null}`))
+	assertEqual(t, e, ErrorHash{"a": ErrBlank})
+
+	e = NewDecoder(&inputs).DecodeMap(&inputs, map[string]interface{}{"a": time.Time{}})
 	assertEqual(t, e, ErrorHash{"a": ErrBlank})
 }
 
@@ -186,6 +203,12 @@ func TestOptionalNullTimeNull(t *testing.T) {
 
 	inputs = withOptionalNullTime{}
 	e = withOptionalNullTimeDecoder.DecodeJSON(&inputs, []byte(`{"a":null}`))
+	assertEqual(t, e, ErrorHash(nil))
+	assertEqual(t, inputs.A.Present, true)
+	assertEqual(t, inputs.A.Null, true)
+	assert(t, inputs.A.Val.IsZero())
+
+	e = withOptionalNullTimeDecoder.DecodeMap(&inputs, map[string]interface{}{"a": time.Time{}})
 	assertEqual(t, e, ErrorHash(nil))
 	assertEqual(t, inputs.A.Present, true)
 	assertEqual(t, inputs.A.Null, true)


### PR DESCRIPTION
DecodeMap is cool but ended up being kind of useless since several of our Valuers didn't handle normal Go types. Here's a first pass at rectifying this.