### PR TITLE
FEATURE: take time expressions, and turn them into values

### DIFF
--- a/time.go
+++ b/time.go
@@ -175,7 +175,8 @@ func (t *Time) FormValue(value string, options interface{}) Errorable {
 	}
 
 	for _, format := range opts.Format {
-		if format == "expression" {
+		switch format {
+		case "expression":
 			for _, parser := range timeExpressionParsers {
 				submatches := parser.Regexp.FindStringSubmatch(value)
 				if len(submatches) == 0 {
@@ -187,12 +188,12 @@ func (t *Time) FormValue(value string, options interface{}) Errorable {
 					return nil
 				}
 			}
-		}
-
-		if v, err := time.Parse(format, value); err == nil {
-			t.Val = v
-			t.Present = true
-			return nil
+		default:
+			if v, err := time.Parse(format, value); err == nil {
+				t.Val = v
+				t.Present = true
+				return nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Provides convenience for scenarios where the client needs to load a
relative time that is dynamically calculated every time it is accessed.
This could be considered a UI concern, but this allows various clients
to reuse the approach instead of re-implementing it.